### PR TITLE
Adding cloudformation template to create an EC2 instance

### DIFF
--- a/service/aws/README.md
+++ b/service/aws/README.md
@@ -1,3 +1,21 @@
 # AWS
-The AWS section can contain a single cloudformation template 'service.template' to provision the service.
+The AWS section can contain a single cloudformation template 'service.template', and a tokenisable Nginx configuration file, 'ec2-extension.conf', in order to provision the service.
+
+This skeleton cloudformation template provided will provision a single EC2-instance using a set of AWS-specific parameters provided to Jenkins as environment variables, upon spinning your instance of ADOP. The parameters are as follows:
+- The VPC where you wish to spin up your instance (this will be set to the VPC where your ADOP instance is provisioned)
+- The subnet where you wish you to spin up your instance which can be either public or private (if a subnet is not set, the subnet where your ADOP instance is provisioned will be used)
+- An AWS keypair in order to gain SSH access to the box (if one is not provided, this will be set to the keypair used to access your ADOP instance)
+- An EC2 instance type (set to t2.large by default)
+
+Additionally, the cloudformation template installs Apache HTTPD server on the host in order to act as a front-end validator when accessing your host. The HTTPD service is made to listen on port 8080.
+
+You will need to add your AWS Access Key and Secret Access Key as global credentials in Jenkins so that it can be picked by the platform extension loader. You will then have to update the Load_Platform_Extension job to ensure the Username and Password binding uses your specified AWS credentials.
+
+The Nginx config file is tokenised with the outputs of the cloudformation template and uploaded to the Nginx volume. We use the xip.io DNS resolver as a proxy configuration.
+
+**Points to note:**
+- The instance is provided with a public IP in order to allow it outbound internet connectivity. In the case where you are spinning up your instance in a subnet which is connected to a NAT host, you may want to set the AssociatePublicIpAddress option to false (if it is not set to false, the traffic will be routed through the NAT anyway).
+- By default, ports 80, 22, 443 and 8080 have been opened up to VPC where you spin up your instance. The VPC CIDR block is provided to the cloudformation template as an input parameter and the security group rules use this parameter. In the case where you are accessing your instance through Nginx proxy, you will have to check the security groups for the host where Nginx resides.
+ 
+It is recommended that you clone this repository and make additions and changes to the cloudformation template and Nginx config file as appropriate. *Do not remove any of the default parameters or outputs from the template as these are all used by the Load_Platform_Extension Jenkins job. Care needs to be taken when making significant changes to the template in order to ensure it is still compatible with the extension loader.*
 

--- a/service/aws/ec2-extension.conf
+++ b/service/aws/ec2-extension.conf
@@ -1,0 +1,18 @@
+server{
+  listen 80;
+  server_name ~^###EC2_SERVICE_NAME###\.*;
+
+  access_log  /var/log/nginx/access.log logstash;
+  proxy_set_header host $host;
+
+  auth_ldap "Forbidden";
+  auth_ldap_servers adop;
+
+  location /{
+	proxy_pass  http://###EC2_HOST_IP###:8080/;
+	proxy_http_version 1.1;
+	proxy_set_header Upgrade $http_upgrade;
+	proxy_set_header Connection "upgrade";
+	proxy_set_header Host $host;
+  }
+}

--- a/service/aws/service.template
+++ b/service/aws/service.template
@@ -1,0 +1,201 @@
+{
+    "Description": "EC2 platform extension template for ADOP/B",
+    "Mappings": {
+        "RegionMap": {
+            "eu-central-1": {
+                "AMI": "ami-9bf712f4"
+            },
+            "eu-west-1": {
+                "AMI": "ami-7abd0209"
+            },
+            "us-east-1": {
+                "AMI": "ami-6d1c2007"
+            },
+            "us-west-1": {
+                "AMI": "ami-af4333cf"
+            },
+            "us-west-2": {
+                "AMI": "ami-d2c924b2"
+            }
+        }
+    },
+    "Outputs": {
+        "EC2InstancePrivateIp": {
+            "Description": "EC2Instance Private IP",
+            "Value": {
+                "Fn::GetAtt": [
+                    "EC2Instance",
+                    "PrivateIp"
+                ]
+            }
+        },
+        "EC2InstanceID" : {
+            "Description": "EC2Instance ID",  
+            "Value" : { "Ref" : "EC2Instance" }
+        }
+    },
+    "Parameters": {
+        "EnvironmentName": {
+            "Description": "The name of the EC2 instance being created",
+            "Type": "String"
+        },
+        "EnvironmentSubnet": {
+            "Description": "The ID of the subnet to create the instance in",
+            "Type": "AWS::EC2::Subnet::Id"
+        },
+        "InstanceType": {
+            "Default": "t2.large",
+            "Description": "EC2 instance type",
+            "Type": "String"
+        },
+        "KeyName": {
+            "Description": "Key-pair name to use.",
+            "Type": "AWS::EC2::KeyPair::KeyName"
+        },
+        "VPCId": {
+            "Description": "VPC ID where the instance will be created",
+            "Type": "AWS::EC2::VPC::Id"
+        },
+        "InboundCIDR": {
+            "Default": "10.0.0.0/16",
+            "Description": "Inbound Security Group CIDR Block",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "DefaultSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Enabling access to all IPs and below listed ports",
+                "SecurityGroupEgress": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": "0",
+                        "IpProtocol": "tcp",
+                        "ToPort": "65535"
+                    },
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "FromPort": "0",
+                        "IpProtocol": "udp",
+                        "ToPort": "65535"
+                    }
+                ],
+                "SecurityGroupIngress": [
+                    {
+                        "CidrIp": {
+                            "Ref": "InboundCIDR"
+                        },
+                        "FromPort": "22",
+                        "IpProtocol": "tcp",
+                        "ToPort": "22"
+                    },
+                    {
+                        "CidrIp": {
+                            "Ref": "InboundCIDR"
+                        },
+                        "FromPort": "80",
+                        "IpProtocol": "tcp",
+                        "ToPort": "80"
+                    },
+                    {
+                        "CidrIp":  {
+                            "Ref": "InboundCIDR"
+                        },
+                        "FromPort": "443",
+                        "IpProtocol": "tcp",
+                        "ToPort": "443"
+                    },
+                    {
+                        "CidrIp":  {
+                            "Ref": "InboundCIDR"
+                        },
+                        "FromPort": "8080",
+                        "IpProtocol": "tcp",
+                        "ToPort": "8080"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPCId"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "EC2Instance": {
+            "Properties": {
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "DeleteOnTermination": "true",
+                            "VolumeSize": 50
+                        }
+                    }
+                ],
+                "ImageId": {
+                    "Fn::FindInMap": [
+                        "RegionMap",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        "AMI"
+                    ]
+                },
+                "InstanceType": {
+                    "Ref": "InstanceType"
+                },
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "NetworkInterfaces": [
+                    {
+                        "AssociatePublicIpAddress": "true",
+                        "DeleteOnTermination": "true",
+                        "DeviceIndex": "0",
+                        "GroupSet": [
+                            {
+                                "Ref": "DefaultSecurityGroup"
+                            }
+                        ],
+                        "SubnetId": {
+                            "Ref": "EnvironmentSubnet"
+                        }
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Ref": "EnvironmentName"
+                        }
+                    },
+                    {
+                        "Key": "createdFor",
+                        "Value": {
+                            "Ref": "EnvironmentName"
+                        }
+                    }
+                ],
+                "UserData": {
+                    "Fn::Base64": {
+                        "Fn::Join": [
+                            "",
+                            [
+                                "#!/bin/bash\n",
+                                "export IP=$(hostname --ip-address)\n",
+                                "NODE=",
+                                {
+                                    "Ref": "EnvironmentName"
+                                },
+                                "\n",
+                                "yum install -y httpd\n",
+                                "echo \"Listen 8080\" >> /etc/httpd/conf/httpd.conf\n",
+                                "service httpd start\n"
+                            ]
+                        ]
+                    }
+                }
+            },
+            "Type": "AWS::EC2::Instance"
+        }
+    }
+}


### PR DESCRIPTION
- Centos Ec2 Instance (based on swarm AMI map) with a sample HTTPD server.
- Public IP specified for outbound internet connectivity
- Secutity group restricted to VPC CIDR block
- Inputs: VPC, subnet, keypair, name, Inbound CIDR, Instance type
- Outputs: Private IP, Instance ID
