### PR TITLE
Adding specification of job DSL groovy service extension for Jenkins

### DIFF
--- a/service_ext/jenkins/job_dsl_additional_classpath/README.md
+++ b/service_ext/jenkins/job_dsl_additional_classpath/README.md
@@ -1,0 +1,2 @@
+# Job DSL Addtional Classpath
+This section allows you to define groovy objects which can be placed in a pre-defined location in Jenkins so that the Job DSL plugin can refer back to these objects.

--- a/service_ext/jenkins/job_dsl_additional_classpath/pluggable/README.md
+++ b/service_ext/jenkins/job_dsl_additional_classpath/pluggable/README.md
@@ -1,0 +1,2 @@
+# Pluggable Library
+This library contains re-usable classes which will return appropriate closures to be used by your cartridge DSL files.

--- a/service_ext/jenkins/job_dsl_additional_classpath/pluggable/scm/README.md
+++ b/service_ext/jenkins/job_dsl_additional_classpath/pluggable/scm/README.md
@@ -1,0 +1,2 @@
+# Pluggable SCM
+This library provides a mechanism to enable multiple SCM support (Gerrit, BitBucket) for cartridges.

--- a/service_ext/jenkins/job_dsl_additional_classpath/pluggable/scm/template/README.md
+++ b/service_ext/jenkins/job_dsl_additional_classpath/pluggable/scm/template/README.md
@@ -1,0 +1,5 @@
+# SCM Provider
+Defining your SCM provider is a matter of creating some Groovy classes to implement the required functionality. You will have a Factory method which parses the properties objects, and returns them to your instance of SCMProvider. You will then have the main implementation which, at the minimum, needs to be able to do the following:
+* Create the repositories defined in urls.txt inside your SCM provider under the correct namespace chosen via Load_Cartridge
+* Return the DSL closure block for doing an SCM clone based on correct input parameters
+* Return the DSL closure block for doing a trigger on a push based on correct input parameters

--- a/service_ext/jenkins/job_dsl_additional_classpath/pluggable/scm/template/TemplateSCMProvider.groovy
+++ b/service_ext/jenkins/job_dsl_additional_classpath/pluggable/scm/template/TemplateSCMProvider.groovy
@@ -1,0 +1,101 @@
+
+package pluggable.scm.template;
+
+import pluggable.scm.SCMProvider;
+
+import pluggable.configuration.EnvVarProperty;
+import pluggable.scm.helpers.ExecuteShellCommand;
+import pluggable.scm.helpers.Logger;
+
+/**
+* This class implements your chosen SCM Provider.
+*/
+public class TemplateSCMProvider implements SCMProvider {
+
+  private final def sampleProperty = null;
+
+  /**
+  * Constructor for class a sample SCMProvider.
+  * @param sampleProperty An example property to be used in your constructor
+  */
+  public TemplateSCMProvider(def sampleProperty){
+
+      this.sampleProperty = sampleProperty;
+
+  }
+
+
+  /**
+  * Creates relevant repositories defined by your cartridge in your chosen SCM provider
+  * @param workspace Workspace of the cartridge loader job
+  * @param repoNamespace Location in your SCM provider where your repositories will be created
+  * @param overwriteRepos Whether the contents of your created repositories are over-written or not
+  **/
+  public void createScmRepos(String workspace, String repoNamespace, String codeReviewEnabled, String overwriteRepos) {
+		
+	// Calling a helper class to allow execution of shell commands on your Jenkins instance
+	ExecuteShellCommand com = new ExecuteShellCommand()
+
+	// Defaults
+	String cartHome = "/cartridge"
+	String urlsFile = workspace + cartHome + "/src/urls.txt"
+    
+	// Class to provide access to all Jenkins environment variables
+	EnvVarProperty envVarProperty = EnvVarProperty.getInstance();
+
+	// Check if code review has been enabled
+	if(codeReviewEnabled.equals("true") && this.scmCodeReviewEnabled.equals("false")){
+	  throw new IllegalArgumentException("You have tried to use code review however it is not supported for your chosen SCM provider.");
+	}
+
+	// Create repositories
+	String command1 = "cat " + urlsFile
+	List<String> repoList = new ArrayList<String>();
+	repoList = (com.executeCommand(command1).split("\\r?\\n"));
+
+	for(String repo: repoList) {
+		// Defaults
+		String repoName = repo.substring(repo.lastIndexOf("/") + 1, repo.indexOf(".git"));
+		String target_repo_name= repoNamespace + "/" + repoName
+		int repo_exists=0;
+
+		// Check if the repository already exists or not
+		// If not, create it
+		// Populate repository
+
+		Logger.info("This is how you to log to the Jenkins system console");  	
+
+	}
+  }
+
+  /**
+    Return SCM section.
+
+    @param projectName - name of the project.
+    @param repoName  - name of the repository to clone.
+    @param branchName - name of branch.
+    @param credentialId - name of the credential in the Jenkins credential
+            manager to use.
+    @param extras - extra closures to add to the SCM section.
+    @return a closure representation of the SCM providers SCM section.
+  **/
+  public Closure get(String projectName, String repoName, String branchName, String credentialId, Closure extras){
+    if(extras == null) extras = {}
+        return {
+
+        }
+    }
+
+    /**
+    * Return a closure representation of the SCM providers trigger SCM section.
+    * @param projectName - project name.
+    * @param repoName - repository name.
+    * @param branchName - branch name to trigger.
+    * @return a closure representation of the SCM providers trigger SCM section.
+    */
+    public Closure trigger(String projectName, String repoName, String branchName) {
+        return {
+
+        }
+    }
+}

--- a/service_ext/jenkins/job_dsl_additional_classpath/pluggable/scm/template/TemplateSCMProviderFactory.groovy
+++ b/service_ext/jenkins/job_dsl_additional_classpath/pluggable/scm/template/TemplateSCMProviderFactory.groovy
@@ -1,0 +1,32 @@
+
+package pluggable.scm.template;
+
+import pluggable.scm.SCMProvider;
+import pluggable.scm.SCMProviderFactory;
+import pluggable.scm.SCMProviderInfo;
+
+/**
+* This is an example SCM factory class responsible for parsing the
+* providers properties and instantiating an SCMProvider.
+*/
+@SCMProviderInfo(type="template")
+public class TemplateSCMProviderFactory implements SCMProviderFactory {
+
+  /**
+  * A factory method which return an SCM Provider instantiated with the
+  * the provided properties.
+  *
+  * @param scmProviderProperties - properties for the SCM provider.
+  * @return SCMProvider configured from the provided SCM properties.
+  **/
+  public SCMProvider create(Properties scmProviderProperties){
+
+    TemplateSCMProvider scmProvider = null;
+
+    String sampleProperty = scmProviderProperties.getProperty("sample.property");
+
+    scmProvider = new TemplateSCMProvider(sampleProperty);
+
+    return scmProvider;
+  }
+}


### PR DESCRIPTION
Introducing the specification for a new type of platform extension, enabling you add additional groovy classes/packages in an addtional classpath, to be consumed by Job DSL in Jenkins. Thus any classes in the **job_dsl_addtional_classpath** folder will be consumable within your Jenkins jobs.

The specification includes sample classes to add an SCM provider to be used by ADOP cartridges, as part of the _pluggable_ package, in order to dynamically replace cartridge content. In theory, the package can be extended to dynamically replace other cartridge contents too. 